### PR TITLE
Pass the namespace as an argument rather than hard coding it

### DIFF
--- a/1.7/listing-pods/main.go
+++ b/1.7/listing-pods/main.go
@@ -10,7 +10,12 @@ import (
 )
 
 func main() {
-	pl, _ := listpods("default")
+	//fmt.Print("In main")
+	if len(os.Args) != 2 {
+		os.Exit(-1)
+	}
+	namespace := os.Args[1]
+	pl, _ := listpods(namespace)
 	fmt.Println(pl)
 }
 


### PR DESCRIPTION
Currently, the namespace is being hardcoded. with this change, we will be able to pass it as an argument.